### PR TITLE
Fix trimText()

### DIFF
--- a/htmlinfo/htmlinfo.go
+++ b/htmlinfo/htmlinfo.go
@@ -254,10 +254,11 @@ func (info *HTMLInfo) Parse(s io.Reader, pageURL *string, contentType *string) e
 
 func (info *HTMLInfo) trimText(text string, maxLen int) string {
 	var numRunes = 0
-	for index := range text {
+	runes := []rune(text)
+	for index := range runes {
 		numRunes++
 		if numRunes > maxLen {
-			return text[:index-3] + "..."
+			return string(runes[:index-3]) + "..."
 		}
 	}
 	return text


### PR DESCRIPTION
trimText could return an invalid utf string in some cases because the string is treated as array of characters and trimming may cut a multi byte character